### PR TITLE
breaking: Rename tracker.Error() --> tracker.Add()

### DIFF
--- a/gournal.go
+++ b/gournal.go
@@ -29,8 +29,8 @@ func (tracker *Tracker) Next() {
 	tracker.Count++
 }
 
-// Error stores non nil errors
-func (tracker *Tracker) Error(err error) {
+// Add stores non nil errors
+func (tracker *Tracker) Add(err error) {
 	if err != nil {
 		cycleErrors, ok := tracker.Errors[tracker.Count]
 		if !ok {

--- a/gournal.go
+++ b/gournal.go
@@ -41,6 +41,7 @@ func (tracker *Tracker) Error(err error) {
 	}
 }
 
+// ErrorsInCycleN returns errors recorded during the specified cycle
 func (tracker Tracker) ErrorsInCycleN(cycle int) ([]error, error) {
 	if cycle < 0 || cycle > tracker.Count {
 		return nil, errors.New("Invalid cycle")
@@ -48,7 +49,7 @@ func (tracker Tracker) ErrorsInCycleN(cycle int) ([]error, error) {
 	return tracker.Errors[cycle], nil
 }
 
-// ErrorsInCurrentCycle returns errors recorded during the cycle
+// ErrorsInCurrentCycle returns errors recorded during the current cycle
 func (tracker Tracker) ErrorsInCurrentCycle() []error {
 	res, _ := tracker.ErrorsInCycleN(tracker.Count)
 	return res

--- a/gournal_test.go
+++ b/gournal_test.go
@@ -3,7 +3,6 @@ package gournal
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"testing"
 )
 
@@ -83,7 +82,7 @@ func Test_CountError(t *testing.T) {
 func Test_HasErrorInCycleN(t *testing.T) {
 	tracker := NewTracker(nil, nil)
 
-	if b, err := tracker.HasErrorInCycleN(nil, 0); !b && err == nil {
+	if b, err := tracker.HasErrorInCycleN(0); !b && err == nil {
 		t.Log("New tracker has no error: Ok")
 	} else {
 		t.Fatal("New tracker has no error: Fail")
@@ -93,12 +92,12 @@ func Test_HasErrorInCycleN(t *testing.T) {
 	tracker.Error(errors.New("error 2"))
 	tracker.Error(errors.New("error 3"))
 
-	if b, err := tracker.HasErrorInCycleN(nil, 0); b && err == nil {
+	if b, err := tracker.HasErrorInCycleN(0); b && err == nil {
 		t.Log("tracker has errors: Ok ")
 	} else {
 		t.Fatal("Tracker has errors: Fail")
 	}
-	if _, err := tracker.HasErrorInCycleN(nil, -1); err != nil {
+	if _, err := tracker.HasErrorInCycleN(-1); err != nil {
 		t.Log("Incorrect cycle fails: Ok ")
 	} else {
 		t.Fatal("Incorrect cycle fails: Fail")
@@ -108,7 +107,7 @@ func Test_HasErrorInCycleN(t *testing.T) {
 func Test_HasErrorInCurrentCycle(t *testing.T) {
 	tracker := NewTracker(nil, nil)
 
-	if !tracker.HasErrorInCurrentCycle(nil) {
+	if !tracker.HasErrorInCurrentCycle() {
 		t.Log("New tracker has no error: Ok")
 	} else {
 		t.Fatal("New tracker has no error: Fail")
@@ -118,37 +117,21 @@ func Test_HasErrorInCurrentCycle(t *testing.T) {
 	tracker.Error(errors.New("error 2"))
 	tracker.Error(errors.New("error 3"))
 
-	if tracker.HasErrorInCurrentCycle(nil) {
+	if tracker.HasErrorInCurrentCycle() {
 		t.Log("Tracker with 3 errors in the current cycle has errors: Ok")
 	} else {
 		t.Fatal("Tracker with 3 errors in the current cycle has errors: Fail")
 	}
 
-	regexp1, err1 := regexp.Compile("^[^error]")
-	regexp2, err2 := regexp.Compile("[^1]$")
-	if err1 != nil || err2 != nil {
-		panic("Wrong regexp !")
-	}
-	if !tracker.HasErrorInCurrentCycle(regexp1) {
-		t.Log("Tracker with filtered errors returns no error: OK")
-	} else {
-		t.Fatal("Tracker with filtered errors returns no error: FAIL")
-	}
-	if tracker.HasErrorInCurrentCycle(regexp2) {
-		t.Log("Tracker with remaining errors returns an error: OK")
-	} else {
-		t.Fatal("Tracker with remaining errors returns an error: FAIL")
-	}
-
 	tracker.Next()
-	if !tracker.HasErrorInCurrentCycle(nil) {
+	if !tracker.HasErrorInCurrentCycle() {
 		t.Log("Tracker with new cycle has no errors: Ok")
 	} else {
 		t.Fatal("Tracker with new cycle has no errors: Fail")
 	}
 
 	tracker.Error(nil)
-	if !tracker.HasErrorInCurrentCycle(nil) {
+	if !tracker.HasErrorInCurrentCycle() {
 		t.Log("Tracker cycle with nil Error has no errors: Ok")
 	} else {
 		t.Fatal("Tracker with nil Error has no errors: Fail")
@@ -158,7 +141,7 @@ func Test_HasErrorInCurrentCycle(t *testing.T) {
 func Test_ErrorsInCycleN(t *testing.T) {
 	tracker := NewTracker(nil, nil)
 
-	if errs, err := tracker.ErrorsInCycleN(nil, 0); errs == nil && err == nil {
+	if errs, err := tracker.ErrorsInCycleN(0); errs == nil && err == nil {
 		t.Log("New tracker has no error: Ok")
 	} else {
 		t.Fatal("New tracker has no error: Fail")
@@ -167,7 +150,7 @@ func Test_ErrorsInCycleN(t *testing.T) {
 	tracker.Error(errors.New("test error 2"))
 	tracker.Next()
 
-	if errs, err := tracker.ErrorsInCycleN(nil, 0); err == nil &&
+	if errs, err := tracker.ErrorsInCycleN(0); err == nil &&
 		errs[0].Error() == "test error 1" &&
 		errs[1].Error() == "test error 2" {
 		t.Log("Tracker with 2 errors in current cycle has 2 errors: Ok")
@@ -175,7 +158,7 @@ func Test_ErrorsInCycleN(t *testing.T) {
 		t.Fatal("Tracker with 2 errors in current cycle has 2 errors: Fail")
 	}
 
-	if errs, err := tracker.ErrorsInCycleN(nil, 2); errs == nil && err != nil {
+	if errs, err := tracker.ErrorsInCycleN(2); errs == nil && err != nil {
 		t.Log("Invalid cycle fails: OK")
 	} else {
 		t.Fatal("Invalid cycle fails: Fail")
@@ -185,7 +168,7 @@ func Test_ErrorsInCycleN(t *testing.T) {
 func Test_ErrorsInCurrentCycle(t *testing.T) {
 	tracker := NewTracker(nil, nil)
 
-	if tracker.ErrorsInCurrentCycle(nil) == nil {
+	if tracker.ErrorsInCurrentCycle() == nil {
 		t.Log("New tracker has no error: Ok")
 	} else {
 		t.Fatal("New tracker has no error: Fail")
@@ -194,29 +177,20 @@ func Test_ErrorsInCurrentCycle(t *testing.T) {
 	tracker.Error(errors.New("test error 1"))
 	tracker.Error(errors.New("test error 2"))
 
-	if len(tracker.ErrorsInCurrentCycle(nil)) == 2 {
+	if len(tracker.ErrorsInCurrentCycle()) == 2 {
 		t.Log("Tracker with 2 errors in current cycle has 2 errors: Ok")
 	} else {
 		t.Fatal("Tracker with 2 errors in current cycle has 2 errors: Fail")
 	}
 
-	if tracker.ErrorsInCurrentCycle(nil)[0].Error() == "test error 1" && tracker.ErrorsInCurrentCycle(nil)[1].Error() == "test error 2" {
+	if tracker.ErrorsInCurrentCycle()[0].Error() == "test error 1" && tracker.ErrorsInCurrentCycle()[1].Error() == "test error 2" {
 		t.Log("Tracker keeps the good errors in the good order: Ok")
 	} else {
 		t.Fatal("Tracker keeps the good errors in the good order: Fail")
 	}
-	regexp, err := regexp.Compile("[^1]$")
-	if err != nil {
-		panic("Wrong regexp !")
-	}
-	if tracker.ErrorsInCurrentCycle(regexp)[0].Error() == "test error 2" {
-		t.Log("Tracker keeps the good errors after filter: Ok")
-	} else {
-		t.Fatal("Tracker keeps the good errors after filter: Fail")
-	}
 	tracker.Next()
-	fmt.Println(tracker.ErrorsInCurrentCycle(nil) == nil)
-	if tracker.ErrorsInCurrentCycle(nil) == nil {
+	fmt.Println(tracker.ErrorsInCurrentCycle() == nil)
+	if tracker.ErrorsInCurrentCycle() == nil {
 		t.Log("Tracker with error and a brand new cycle has no error: Ok")
 	} else {
 		t.Fatal("Tracker with error and a brand new cycle has no error: Fail")

--- a/gournal_test.go
+++ b/gournal_test.go
@@ -57,13 +57,13 @@ func Test_CountError(t *testing.T) {
 		t.Fatal("CountError == 0: Fail")
 	}
 
-	tracker.Error(errors.New("error 1"))
-	tracker.Error(errors.New("error 2"))
-	tracker.Error(errors.New("error 3"))
+	tracker.Add(errors.New("error 1"))
+	tracker.Add(errors.New("error 2"))
+	tracker.Add(errors.New("error 3"))
 	tracker.Next()
-	tracker.Error(errors.New("error 1"))
-	tracker.Error(errors.New("error 2"))
-	tracker.Error(errors.New("error 3"))
+	tracker.Add(errors.New("error 1"))
+	tracker.Add(errors.New("error 2"))
+	tracker.Add(errors.New("error 3"))
 	tracker.Next()
 	tracker.Next()
 
@@ -88,9 +88,9 @@ func Test_HasErrorInCycleN(t *testing.T) {
 		t.Fatal("New tracker has no error: Fail")
 	}
 
-	tracker.Error(errors.New("error 1"))
-	tracker.Error(errors.New("error 2"))
-	tracker.Error(errors.New("error 3"))
+	tracker.Add(errors.New("error 1"))
+	tracker.Add(errors.New("error 2"))
+	tracker.Add(errors.New("error 3"))
 
 	if b, err := tracker.HasErrorInCycleN(0); b && err == nil {
 		t.Log("tracker has errors: Ok ")
@@ -113,9 +113,9 @@ func Test_HasErrorInCurrentCycle(t *testing.T) {
 		t.Fatal("New tracker has no error: Fail")
 	}
 
-	tracker.Error(errors.New("error 1"))
-	tracker.Error(errors.New("error 2"))
-	tracker.Error(errors.New("error 3"))
+	tracker.Add(errors.New("error 1"))
+	tracker.Add(errors.New("error 2"))
+	tracker.Add(errors.New("error 3"))
 
 	if tracker.HasErrorInCurrentCycle() {
 		t.Log("Tracker with 3 errors in the current cycle has errors: Ok")
@@ -130,7 +130,7 @@ func Test_HasErrorInCurrentCycle(t *testing.T) {
 		t.Fatal("Tracker with new cycle has no errors: Fail")
 	}
 
-	tracker.Error(nil)
+	tracker.Add(nil)
 	if !tracker.HasErrorInCurrentCycle() {
 		t.Log("Tracker cycle with nil Error has no errors: Ok")
 	} else {
@@ -146,8 +146,8 @@ func Test_ErrorsInCycleN(t *testing.T) {
 	} else {
 		t.Fatal("New tracker has no error: Fail")
 	}
-	tracker.Error(errors.New("test error 1"))
-	tracker.Error(errors.New("test error 2"))
+	tracker.Add(errors.New("test error 1"))
+	tracker.Add(errors.New("test error 2"))
 	tracker.Next()
 
 	if errs, err := tracker.ErrorsInCycleN(0); err == nil &&
@@ -174,8 +174,8 @@ func Test_ErrorsInCurrentCycle(t *testing.T) {
 		t.Fatal("New tracker has no error: Fail")
 	}
 
-	tracker.Error(errors.New("test error 1"))
-	tracker.Error(errors.New("test error 2"))
+	tracker.Add(errors.New("test error 1"))
+	tracker.Add(errors.New("test error 2"))
 
 	if len(tracker.ErrorsInCurrentCycle()) == 2 {
 		t.Log("Tracker with 2 errors in current cycle has 2 errors: Ok")


### PR DESCRIPTION
## Proposed changes

- Rename `tracker.Error()` --> `tracker.Add()`, to improve the readability of error handling in [opensignauxfaibles](https://github.com/signaux-faibles/opensignauxfaibles)' file parsers, as discussed with Pierre. (cf https://github.com/signaux-faibles/opensignauxfaibles/pull/175)
- Fix broken tests, and remove the ones which refer to features that are not implemented.
- Fix Godoc of 2 methods.

![image](https://user-images.githubusercontent.com/531781/94786634-81766400-03d1-11eb-9c13-438517d609ea.png)
